### PR TITLE
MSFT_xVMDvdDrive: Fixing incorrect property in example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* MSFT_xVMDvdDrive
+  * Fixed VMName property in example
+
 ## 3.17.0.0
 
 * MSFT_xVMNetworkAdapter:

--- a/Examples/Sample_xVMHyperV_SimpleWithDVDDrive.ps1
+++ b/Examples/Sample_xVMHyperV_SimpleWithDVDDrive.ps1
@@ -38,7 +38,7 @@ configuration Sample_xVMHyperV_SimpleWithDvdDrive
         xVMDvdDrive NewVMDvdDriveISO
         {
             Ensure             = 'Present'
-            Name               = $VMName
+            VMName               = $VMName
             ControllerNumber   = 0
             ControllerLocation = 0
             Path               = $ISOPath


### PR DESCRIPTION
#### Pull Request (PR) description
Replaced incorrect Name property in example with VMName

#### This Pull Request (PR) fixes the following issues
Fixes #177

#### Task list
- [X] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [X] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xhyper-v/178)
<!-- Reviewable:end -->
