### PR TITLE
xVhdFileDirectory - improvements and fixes to Content files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 DSCResource.Tests
+/.vs

--- a/DSCResources/MSFT_xVhdFileDirectory/MSFT_xVhdFileDirectory.schema.mof
+++ b/DSCResources/MSFT_xVhdFileDirectory/MSFT_xVhdFileDirectory.schema.mof
@@ -9,6 +9,7 @@ Class MSFT_xFileDirectory
   [Write] boolean Recurse;
   [Write] boolean Force ;
   [write] string Content;
+  [write] string ContentEncoding;
   [Write,ValueMap{"ReadOnly", "Hidden", "System", "Archive"},Values{"ReadOnly", "Hidden", "System", "Archive"}] string Attributes[];
 };
 


### PR DESCRIPTION

#### Pull Request (PR) description
1. Added ContentEncoding property to properly support Content files (otherwise they are always written as Unicode) which corrupts some content types like UTF-8 XMLs.
2. Content files are not tested with ItemHasChanged (this didn't work anyway).
3. Fixed GetItemToCopy where an undefined DefaultValues array was used instead of DesiredProperties, resulting in a dead code, impacting properties like Force.
4. After #3 is fixed and the code is finally execuded, it would crash if a file is a Content (without SourcePath).
5. In SetVHDFile , Copy-Item's ErrorAction is set to Stop. Otherwise, the resource would simply ignore all errors and produce invalid configuration.



#### This Pull Request (PR) fixes the following issues
None


