### PR TITLE
xVMNetworkAdapter: Fix Get- failing for a ManagementOS adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
   - Fixed VMName property in example.
 - xVMNetworkAdapter
   - Fixed MacAddress sample data.
+  - Fixed Get-TargetResource failing for a ManagementOS adapter while trying
+    to obtain guest IP settings.
 - xVMSwitch
   - Correctly return the state as `$true` or `$false` depending on the
     `Ensure` property when the switch does not exist.

--- a/source/DSCResources/MSFT_xVMNetworkAdapter/MSFT_xVMNetworkAdapter.psm1
+++ b/source/DSCResources/MSFT_xVMNetworkAdapter/MSFT_xVMNetworkAdapter.psm1
@@ -83,13 +83,13 @@ function Get-TargetResource
         {
             $configuration.Add('MacAddress', $netAdapter.MacAddress)
             $configuration.Add('DynamicMacAddress', $netAdapter.DynamicMacAddressEnabled)
-        }
 
-        $networkInfo = Get-NetworkInformation -VMName $VMName -Name $Name
-        if ($networkInfo)
-        {
-            $item = New-CimInstance -ClassName MSFT_xNetworkSettings -Property $networkInfo -Namespace root/microsoft/windows/desiredstateconfiguration -ClientOnly
-            $configuration.Add('NetworkSetting', $item)
+            $networkInfo = Get-NetworkInformation -VMName $VMName -Name $Name
+            if ($networkInfo)
+            {
+                $item = New-CimInstance -ClassName MSFT_xNetworkSettings -Property $networkInfo -Namespace root/microsoft/windows/desiredstateconfiguration -ClientOnly
+                $configuration.Add('NetworkSetting', $item)
+            }
         }
 
         $configuration.Add('Ensure', 'Present')


### PR DESCRIPTION
#### Pull Request (PR) description

The Get-NetworkInformation function does not work for a ManagementOS
adapter and should not be called in that code path in Get-TargetResource.

#### This Pull Request (PR) fixes the following issues
None

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
